### PR TITLE
Remove boldcitydowntown.com.

### DIFF
--- a/revil-kaseya-cnc-domains.txt
+++ b/revil-kaseya-cnc-domains.txt
@@ -151,7 +151,6 @@ bodyforwife.com
 bodyfulls.com
 bogdanpeptine.ro
 boisehosting.net
-boldcitydowntown.com
 bookspeopleplaces.com
 boompinoy.com
 boosthybrid.com.au


### PR DESCRIPTION
Removing boldcitydowntown.com.

Site is clean:  
https://www.virustotal.com/gui/url/f592c8cf0b4f2bc394a52bf8f4370ed4bd47330e766c6360f3abfe14f279eea5/detection

Years ago, with a previous WordPress installation/server (likely via a WordPress plug-in), the website appeared to be a REvil C&C server (per https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Ransom:Win32/Sodinokibi&ThreatID=2147741179). But the referenced file in Microsoft's article (https://boldcitydowntown[.]com/static/pics/cqjmvq.png) does not exist.